### PR TITLE
Add a tip about SQS 'Visibility timeout' setting

### DIFF
--- a/lambda_timestream_load_from_dump_to_s3_json.py
+++ b/lambda_timestream_load_from_dump_to_s3_json.py
@@ -35,8 +35,9 @@ Create the Timestream Database and Table:
 When creating the Timestream Table, enable Magnetic Storage Writes and make sure the Magnetic Store rentention period
 is longer than the oldest data point you want to ingest.
 
-Tip:
-Increase the execution time of the Lambda function and memory to allow execution on large objects.
+Tips:
+* Increase the execution time of the Lambda function and memory to allow execution on large objects
+* SQS queue 'Visibility timeout' setting must be equal to or greater than the Lambda maximum execution time
 
 The Role allocated to the Lambda for execution must have the following policies (or less permissive equivalent):
 * AWSLambdaBasicExecutionRole


### PR DESCRIPTION
SQS queue 'Visibility timeout' setting must be equal to or greater than the Lambda maximum execution time